### PR TITLE
Capitalise reference to Janet

### DIFF
--- a/routes/home.janet
+++ b/routes/home.janet
@@ -18,7 +18,7 @@
             :x-data (string/format "searcher('%s')" (url-for :home/searches))}
     [:h1
      [:span "JanetDocs is a community documentation site for the "]
-     [:a {:href "https://janet-lang.org"} "janet programming language"]]
+     [:a {:href "https://janet-lang.org"} "Janet programming language"]]
     [:input {:type "text" :name "token" :placeholder "search docs"
              :autofocus ""
              :style "width: 100%"


### PR DESCRIPTION
I realise this is really more of a style thing and think it's fine to keep as is but I note that the Janet website always refers to the language as 'Janet'.